### PR TITLE
Add mplay command for YouTube integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project provides a [Lavalink](https://github.com/lavalink-devs/Lavalink) pl
 
 ## Features
 
-- Search Melon using the `melonsc:` prefix (e.g. `melonsc:아이유`)
+- Search Melon using the `msearch:` prefix (e.g. `msearch:아이유`)
+- Play the most relevant YouTube result via the `mplay:` prefix
 - Load tracks directly from Melon song URLs
 
 ## Building


### PR DESCRIPTION
## Summary
- rename Melon search prefix from `melonsc:` to `msearch:`
- add `mplay:` prefix that uses the YouTube plugin to play the best matched track
- document new prefixes in README

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689b14a7d36c83309a6e9bb29ec085ac