### PR TITLE
Add basic Melon service support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     compileOnly "dev.arbjerg.lavalink:plugin-api:4.1.1"
+    implementation "org.jsoup:jsoup:1.17.2"
 }
 
 shadowJar {

--- a/src/main/java/cafe/cocochino/melonPlugin/MelonAudioTrack.java
+++ b/src/main/java/cafe/cocochino/melonPlugin/MelonAudioTrack.java
@@ -1,12 +1,14 @@
 package cafe.cocochino.melonPlugin;
 
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.*;
 import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
 
 public class MelonAudioTrack extends DelegatedAudioTrack {
     private final MelonAudioSourceManager sourceManager;
     private final String artworkURL;
+
     public MelonAudioTrack(AudioTrackInfo trackInfo, String artworkURL, MelonAudioSourceManager sourceManager) {
         super(trackInfo);
         this.artworkURL = artworkURL;
@@ -22,9 +24,22 @@ public class MelonAudioTrack extends DelegatedAudioTrack {
         return this.sourceManager;
     }
 
+    @Override
     public void process(LocalAudioTrackExecutor executor) throws Exception {
+        String query = this.getInfo().title + " " + this.getInfo().author;
+        AudioItem item = sourceManager.getPlayerManager().loadItemSync("ytsearch:" + query);
+        AudioTrack delegate = null;
+        if (item instanceof AudioPlaylist playlist && !playlist.getTracks().isEmpty()) {
+            delegate = playlist.getTracks().get(0);
+        } else if (item instanceof AudioTrack track) {
+            delegate = track;
+        }
 
+        if (delegate == null) {
+            throw new FriendlyException("No matching track found for query: " + query,
+                    FriendlyException.Severity.COMMON, null);
+        }
+
+        processDelegate((InternalAudioTrack) delegate, executor);
     }
-
-
 }


### PR DESCRIPTION
## Summary
- parse Melon search and song pages using Jsoup
- load tracks as MelonAudioTrack and delegate playback via YouTube search
- encode artwork information and expose PlayerManager for processing

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_689b21a317a883308d743d5e22bcf06d