### PR TITLE
feat: improve artist extraction

### DIFF
--- a/src/main/java/cafe/cocochino/melonPlugin/MelonAudioSourceManager.java
+++ b/src/main/java/cafe/cocochino/melonPlugin/MelonAudioSourceManager.java
@@ -202,6 +202,15 @@ public class MelonAudioSourceManager implements AudioSourceManager, HttpConfigur
                 }
             }
         }
+        if (artist.isEmpty()) {
+            Element artistEl = doc.selectFirst("div.artist a.artist_name");
+            if (artistEl == null) {
+                artistEl = doc.selectFirst("div.profile-common .user-name");
+            }
+            if (artistEl != null) {
+                artist = artistEl.text().trim();
+            }
+        }
         String artwork = doc.selectFirst("meta[property=og:image]") != null ?
                 doc.selectFirst("meta[property=og:image]").attr("content") : "";
         return createTrack(title, artist, String.valueOf(songNumber), url, artwork);


### PR DESCRIPTION
## Summary
- broaden Melon track parsing to detect artist names in current desktop and mobile layouts

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c1994e9ec48330a270f836aa258cd1