### PR TITLE
docs: add Korean README and language switch

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,38 @@
+[English](README.md) | 한국어
+
+# 멜론 소스 플러그인
+
+이 프로젝트는 [Lavalink](https://github.com/lavalink-devs/Lavalink)용 플러그인으로, [멜론](https://www.melon.com/)의 트랙 재생을 지원합니다.
+
+## 기능
+- `msearch:` 접두사를 사용해 멜론에서 검색 (예: `msearch:아이유`)
+- `mplay:` 접두사를 통해 가장 관련성 높은 YouTube 결과 재생
+- 멜론 곡 URL을 직접 로드
+
+## 빌드
+
+이 플러그인은 **Lavalink 4.x**를 대상으로 하며 **Java 17** 이상이 필요합니다.
+
+```bash
+./gradlew shadowJar
+```
+
+생성된 셰이드 JAR는 `build/libs`에 위치합니다.
+
+## 사용법
+
+생성된 JAR를 Lavalink의 `plugins` 디렉터리에 복사하고 Lavalink 설정에서 플러그인을 활성화하세요.
+
+## 설정
+
+`application.yml`을 통해 플러그인을 활성화하거나 비활성화할 수 있습니다:
+
+```yaml
+plugins:
+  melon:
+    enabled: true
+```
+
+## 라이선스
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+English | [한국어](README.ko.md)
+
 # Melon Source Plugin
 
 This project provides a [Lavalink](https://github.com/lavalink-devs/Lavalink) plugin that adds support for playing tracks from [Melon](https://www.melon.com/).
 
 ## Features
-
 - Search Melon using the `msearch:` prefix (e.g. `msearch:아이유`)
 - Play the most relevant YouTube result via the `mplay:` prefix
 - Load tracks directly from Melon song URLs
@@ -15,6 +16,7 @@ This plugin targets **Lavalink 4.x** and requires **Java 17** or newer.
 ```bash
 ./gradlew shadowJar
 ```
+
 The shaded jar will be located in `build/libs`.
 
 ## Usage


### PR DESCRIPTION
## Summary
- document plugin usage with language switch
- add Korean translation in README.ko.md

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c1a3bd36848330b92b8e84c730e21c