### PR TITLE
Remove search functionality

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -5,7 +5,6 @@
 이 프로젝트는 [Lavalink](https://github.com/lavalink-devs/Lavalink)용 플러그인으로, [멜론](https://www.melon.com/)의 트랙 재생을 지원합니다.
 
 ## 기능
-- `msearch:` 접두사를 사용해 멜론에서 검색 (예: `msearch:아이유`)
 - `mplay:` 접두사를 통해 가장 관련성 높은 YouTube 결과 재생
 - 멜론 곡 URL을 직접 로드
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ English | [한국어](README.ko.md)
 This project provides a [Lavalink](https://github.com/lavalink-devs/Lavalink) plugin that adds support for playing tracks from [Melon](https://www.melon.com/).
 
 ## Features
-- Search Melon using the `msearch:` prefix (e.g. `msearch:아이유`)
 - Play the most relevant YouTube result via the `mplay:` prefix
 - Load tracks directly from Melon song URLs
 


### PR DESCRIPTION
## Summary
- drop `msearch:` support and associated Melon search logic
- streamline `mplay:` handling to search YouTube directly
- update README files to match

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4878de08330a8a8ee5e3eafeb22